### PR TITLE
Fix Netsplit, support plain TCP for debugging

### DIFF
--- a/bots/bot.py
+++ b/bots/bot.py
@@ -60,6 +60,10 @@ class Bot(irc.IRCClient):
             LOG.log("notice", "Successfully authenticated against NickServ")
             for channel in self.factory.channel:
                 self.join(channel)
+        if "NickServ" in user and "registered" in message:
+            LOG.log("notice", "Received notice that nick is registered, reauthenticate...")
+            self.signedOn()
+
 
     def lineReceived(self, line):
         LOG.debug(line)


### PR DESCRIPTION
Deal with Netsplit by
	Reauthenticating when NickServ complains about registered nick.
	Retrying to connect when connection fails (server might be down temporarily)

fixes #46 
fixes #69 